### PR TITLE
Replace screenshots with direct/raw links so left click gives the full image

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ Database editor using HandsOnTable. Can also edit arrays, which will be joined u
 
 ## Screenshots
 
-![](/screenshots/1.png)
-![](/screenshots/2.png)
+![](https://raw.githubusercontent.com/patarapolw/db-editor/master/screenshots/1.png)
+![](https://raw.githubusercontent.com/patarapolw/db-editor/master/screenshots/2.png)


### PR DESCRIPTION
It's just a suggestion or maybe you could say a style but in its current state when I left click on the screenshots in the README, I get linked to their page in the repo and they are even smaller than in the README.

When you reference the raw/direct link on left click you get the full image on the new tab. Feel free to refuse pull if it isn't a nice change. I just thought it'd make it easier to zoom into the images.